### PR TITLE
feat(react/createField): Add ability to provide custom state selector to Field

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Stapp
 
-[![Build Status](https://travis-ci.org/TinkoffCreditSystems/stapp.svg?branch=master)](https://travis-ci.org/TinkoffCreditSystems/stapp) [![Written in typescript](https://img.shields.io/badge/written_in-typescript-blue.svg)](https://www.typescriptlang.org/) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) ![npm](https://img.shields.io/npm/v/stapp.svg)
+[![Build Status](https://travis-ci.org/TinkoffCreditSystems/stapp.svg?branch=master)](https://travis-ci.org/TinkoffCreditSystems/stapp) [![Written in typescript](https://img.shields.io/badge/written_in-typescript-blue.svg)](https://www.typescriptlang.org/) [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com) [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/) ![https://www.npmjs.com/package/stapp](https://img.shields.io/npm/v/stapp.svg)
 
 Stapp is the highly opinionated application state-management tool based on redux and RxJS with significantly reduced boilerplate. The primary goal of Stapp is to provide an easy way to create simple, robust and reusable applications.
 

--- a/docs/modules/formBase.md
+++ b/docs/modules/formBase.md
@@ -105,14 +105,15 @@ type submit = () => Event<void>
 `formBase` is shipped with a bunch of memoized selectors.
 
 ```typescript
-type fieldSelector = (name: string) => <State, Custom>(state: State) => ({
-  value: string | undefined,
-  error: any,
-  dirty: boolean,
-  touched: boolean,
-  active: boolean,
-  custom?: Custom
-})
+type fieldSelector = <State, Extra>(name: string, extraSelector: (state: State) => Extra) => 
+  (state: State) => ({
+    value: string | undefined,
+    error: any,
+    dirty: boolean,
+    touched: boolean,
+    active: boolean,
+    extra?: Extra
+  })
 
 type formSelector = () => <State>(state: State) => ({
     submitting: boolean,

--- a/docs/modules/formBase.md
+++ b/docs/modules/formBase.md
@@ -105,12 +105,13 @@ type submit = () => Event<void>
 `formBase` is shipped with a bunch of memoized selectors.
 
 ```typescript
-type fieldSelector = (name: string) => <State>(state: State) => ({
+type fieldSelector = (name: string) => <State, Custom>(state: State) => ({
   value: string | undefined,
   error: any,
   dirty: boolean,
   touched: boolean,
-  active: boolean
+  active: boolean,
+  custom?: Custom
 })
 
 type formSelector = () => <State>(state: State) => ({

--- a/docs/usage/react.md
+++ b/docs/usage/react.md
@@ -136,7 +136,7 @@ type FormApi = {
 
 type Field<State extends FormBaseState> = React.Component<{
   name: string, // field name
-  customSelector: (state: State) => any
+  customSelector: (state: State) => any,
 
   children?: (props: FieldApi) => React.ReactElement | null,
   render?: (props: FieldApi) => React.ReactElement | null,
@@ -156,7 +156,7 @@ type FieldApi<Custom = undefined> = {
     touched: boolean // field was focused
     active: boolean // field is in focus
     dirty: boolean // field value differs from initial value
-  },
+  }
   custom: Custom
 }
 ```

--- a/docs/usage/react.md
+++ b/docs/usage/react.md
@@ -134,15 +134,16 @@ type FormApi = {
   pristine: boolean // fields were not touched
 }
 
-type Field = React.Component<{
+type Field<State extends FormBaseState> = React.Component<{
   name: string, // field name
+  customSelector: (state: State) => any
 
   children?: (props: FieldApi) => React.ReactElement | null,
   render?: (props: FieldApi) => React.ReactElement | null,
   component?: React.ReactType<FieldApi>
 }>
 
-type FieldApi = {
+type FieldApi<Custom = undefined> = {
   input: {
     name: string
     value: string
@@ -155,7 +156,8 @@ type FieldApi = {
     touched: boolean // field was focused
     active: boolean // field is in focus
     dirty: boolean // field value differs from initial value
-  }
+  },
+  custom: Custom
 }
 ```
 

--- a/docs/usage/react.md
+++ b/docs/usage/react.md
@@ -136,14 +136,14 @@ type FormApi = {
 
 type Field<State extends FormBaseState> = React.Component<{
   name: string, // field name
-  customSelector: (state: State) => any,
+  extraSelector: (state: State) => any,
 
   children?: (props: FieldApi) => React.ReactElement | null,
   render?: (props: FieldApi) => React.ReactElement | null,
   component?: React.ReactType<FieldApi>
 }>
 
-type FieldApi<Custom = undefined> = {
+type FieldApi<Extra = undefined> = {
   input: {
     name: string
     value: string
@@ -157,7 +157,7 @@ type FieldApi<Custom = undefined> = {
     active: boolean // field is in focus
     dirty: boolean // field value differs from initial value
   }
-  custom: Custom
+  extra: Extra
 }
 ```
 

--- a/src/modules/formBase/selectors.spec.ts
+++ b/src/modules/formBase/selectors.spec.ts
@@ -117,30 +117,29 @@ describe('FormBase selectors', () => {
     })
 
     expect(
-      fieldSelector<FormBaseState & { customValue: string }>(
-        'test',
-        ({ customValue }) => customValue
-      )({
-        values: {},
-        errors: {
-          test: 'Some error'
-        },
-        touched: {
-          test: true
-        },
-        dirty: {
-          test: true
-        },
-        active: 'test',
-        customValue: 'Some custom value'
-      })
+      fieldSelector<FormBaseState & { extraValue: string }>('test', ({ extraValue }) => extraValue)(
+        {
+          values: {},
+          errors: {
+            test: 'Some error'
+          },
+          touched: {
+            test: true
+          },
+          dirty: {
+            test: true
+          },
+          active: 'test',
+          extraValue: 'Some value'
+        }
+      )
     ).toEqual({
       value: undefined,
       error: 'Some error',
       touched: true,
       dirty: true,
       active: true,
-      custom: 'Some custom value'
+      extra: 'Some value'
     })
   })
 })

--- a/src/modules/formBase/selectors.spec.ts
+++ b/src/modules/formBase/selectors.spec.ts
@@ -1,3 +1,4 @@
+import { FormBaseState } from './formBase.h'
 import { fieldSelector, isDirtySelector, isReadySelector, isValidSelector } from './selectors'
 
 describe('FormBase selectors', () => {
@@ -113,6 +114,33 @@ describe('FormBase selectors', () => {
       touched: true,
       dirty: true,
       active: true
+    })
+
+    expect(
+      fieldSelector<FormBaseState & { customValue: string }>(
+        'test',
+        ({ customValue }) => customValue
+      )({
+        values: {},
+        errors: {
+          test: 'Some error'
+        },
+        touched: {
+          test: true
+        },
+        dirty: {
+          test: true
+        },
+        active: 'test',
+        customValue: 'Some custom value'
+      })
+    ).toEqual({
+      value: undefined,
+      error: 'Some error',
+      touched: true,
+      dirty: true,
+      active: true,
+      custom: 'Some custom value'
     })
   })
 })

--- a/src/modules/formBase/selectors.ts
+++ b/src/modules/formBase/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createStructuredSelector,  } from 'reselect'
+import { createSelector, createStructuredSelector } from 'reselect'
 import { FormBaseState } from './formBase.h'
 
 export const isValidSelector = () =>
@@ -22,9 +22,11 @@ export const isDirtySelector = () =>
 export const isPristineSelector = () => <State extends FormBaseState>(state: State) =>
   state.pristine
 
+const noop = () => undefined as any
+
 export const fieldSelector = <State extends FormBaseState, Custom = undefined>(
   name: string,
-  customSelector: (state: State) => Custom = () => undefined as any
+  customSelector: (state: State) => Custom = noop
 ) =>
   createStructuredSelector({
     value: (state: State) => state.values[name],

--- a/src/modules/formBase/selectors.ts
+++ b/src/modules/formBase/selectors.ts
@@ -1,4 +1,4 @@
-import { createSelector, createStructuredSelector } from 'reselect'
+import { createSelector, createStructuredSelector,  } from 'reselect'
 import { FormBaseState } from './formBase.h'
 
 export const isValidSelector = () =>
@@ -22,13 +22,17 @@ export const isDirtySelector = () =>
 export const isPristineSelector = () => <State extends FormBaseState>(state: State) =>
   state.pristine
 
-export const fieldSelector = (name: string) =>
+export const fieldSelector = <State extends FormBaseState, Custom = undefined>(
+  name: string,
+  customSelector: (state: State) => Custom = () => undefined as any
+) =>
   createStructuredSelector({
-    value: <State extends FormBaseState>(state: State) => state.values[name],
-    error: <State extends FormBaseState>(state: State) => state.errors[name],
-    dirty: <State extends FormBaseState>(state: State) => !!state.dirty[name],
-    touched: <State extends FormBaseState>(state: State) => !!state.touched[name],
-    active: <State extends FormBaseState>(state: State) => state.active === name
+    value: (state: State) => state.values[name],
+    error: (state: State) => state.errors[name],
+    dirty: (state: State) => !!state.dirty[name],
+    touched: (state: State) => !!state.touched[name],
+    active: (state: State) => state.active === name,
+    custom: customSelector
   })
 
 export const formSelector = () =>

--- a/src/modules/formBase/selectors.ts
+++ b/src/modules/formBase/selectors.ts
@@ -24,9 +24,9 @@ export const isPristineSelector = () => <State extends FormBaseState>(state: Sta
 
 const noop = () => undefined as any
 
-export const fieldSelector = <State extends FormBaseState, Custom = undefined>(
+export const fieldSelector = <State extends FormBaseState, Extra = undefined>(
   name: string,
-  customSelector: (state: State) => Custom = noop
+  extraSelector: (state: State) => Extra = noop
 ) =>
   createStructuredSelector({
     value: (state: State) => state.values[name],
@@ -34,7 +34,7 @@ export const fieldSelector = <State extends FormBaseState, Custom = undefined>(
     dirty: (state: State) => !!state.dirty[name],
     touched: (state: State) => !!state.touched[name],
     active: (state: State) => state.active === name,
-    custom: customSelector
+    extra: extraSelector
   })
 
 export const formSelector = () =>

--- a/src/react/createField/createField.h.ts
+++ b/src/react/createField/createField.h.ts
@@ -1,7 +1,7 @@
 import { SyntheticEvent } from 'react'
 import { RenderProps } from '../createConsumer/createConsumer.h'
 
-export type FieldApi = {
+export type FieldApi<Custom = undefined> = {
   input: {
     name: string
     value: string
@@ -13,9 +13,11 @@ export type FieldApi = {
     error: any
     touched: boolean
     active: boolean
-  }
+  },
+  custom: Custom
 }
 
-export type FieldProps = RenderProps<FieldApi> & {
+export type FieldProps<Custom> = RenderProps<FieldApi<Custom>> & {
   name: string
+  customSelector?: () => Custom
 }

--- a/src/react/createField/createField.h.ts
+++ b/src/react/createField/createField.h.ts
@@ -1,7 +1,7 @@
 import { SyntheticEvent } from 'react'
 import { RenderProps } from '../createConsumer/createConsumer.h'
 
-export type FieldApi<Custom = undefined> = {
+export type FieldApi<Extra = undefined> = {
   input: {
     name: string
     value: string
@@ -13,11 +13,11 @@ export type FieldApi<Custom = undefined> = {
     error: any
     touched: boolean
     active: boolean
-  },
-  custom: Custom
+  }
+  extra: Extra
 }
 
-export type FieldProps<Custom> = RenderProps<FieldApi<Custom>> & {
+export type FieldProps<Extra> = RenderProps<FieldApi<Extra>> & {
   name: string
-  customSelector?: () => Custom
+  extraSelector?: () => Extra
 }

--- a/src/react/createField/createField.tsx
+++ b/src/react/createField/createField.tsx
@@ -48,10 +48,10 @@ import { FieldProps } from './createField.h'
  *
  * @param app Stapp application
  */
-export const createField = <State, Api>(app: Stapp<State, Api>): StatelessComponent<FieldProps> => {
+export const createField = <State, Api>(app: Stapp<State, Api>): StatelessComponent<FieldProps<any>> => {
   const Consumer = createConsumer(app)
 
-  return ({ name, children, render, component }) => {
+  return ({ name, customSelector, children, render, component }) => {
     const handleChange = (event: SyntheticEvent<HTMLInputElement>) =>
       app.dispatch(
         setValue({
@@ -67,8 +67,8 @@ export const createField = <State, Api>(app: Stapp<State, Api>): StatelessCompon
     const handleFocus = () => app.dispatch(setActive(name))
 
     return (
-      <Consumer mapState={fieldSelector(name)}>
-        {({ value, error, dirty, touched, active }) =>
+      <Consumer mapState={fieldSelector(name, customSelector)}>
+        {({ value, error, dirty, touched, active, custom }) =>
           renderComponent(
             {
               children,
@@ -88,7 +88,8 @@ export const createField = <State, Api>(app: Stapp<State, Api>): StatelessCompon
                 touched,
                 active,
                 dirty
-              }
+              },
+              custom
             },
             'Field'
           )

--- a/src/react/createField/createField.tsx
+++ b/src/react/createField/createField.tsx
@@ -48,10 +48,12 @@ import { FieldProps } from './createField.h'
  *
  * @param app Stapp application
  */
-export const createField = <State, Api>(app: Stapp<State, Api>): StatelessComponent<FieldProps<any>> => {
+export const createField = <State, Api>(
+  app: Stapp<State, Api>
+): StatelessComponent<FieldProps<any>> => {
   const Consumer = createConsumer(app)
 
-  return ({ name, customSelector, children, render, component }) => {
+  return ({ name, extraSelector, children, render, component }) => {
     const handleChange = (event: SyntheticEvent<HTMLInputElement>) =>
       app.dispatch(
         setValue({
@@ -67,8 +69,8 @@ export const createField = <State, Api>(app: Stapp<State, Api>): StatelessCompon
     const handleFocus = () => app.dispatch(setActive(name))
 
     return (
-      <Consumer mapState={fieldSelector(name, customSelector)}>
-        {({ value, error, dirty, touched, active, custom }) =>
+      <Consumer mapState={fieldSelector(name, extraSelector)}>
+        {({ value, error, dirty, touched, active, extra }) =>
           renderComponent(
             {
               children,
@@ -89,7 +91,7 @@ export const createField = <State, Api>(app: Stapp<State, Api>): StatelessCompon
                 active,
                 dirty
               },
-              custom
+              extra
             },
             'Field'
           )


### PR DESCRIPTION
Add property 'customSelector' of type '(state: State) => any' to Field, the result of 'customSelector' goes to 'custom' property of render props