### PR TITLE
Validation with plain object errors

### DIFF
--- a/src/modules/validate/helpers.ts
+++ b/src/modules/validate/helpers.ts
@@ -16,21 +16,13 @@ import { ValidationFlags, ValidationRule } from './validate.h'
 /**
  * @private
  */
-export const normalizeResult = (
-  fieldName: string,
-  result: any
-): Observable<Event<any, any>> => {
+export const normalizeResult = (fieldName: string, result: any): Observable<Event<any, any>> => {
   // if it's a promise, unwrap
   if (isPromise(result)) {
     return fromPromise(result).pipe(
       switchMap((promiseResult) => normalizeResult(fieldName, promiseResult)),
       catchError((error) => of(setError({ [fieldName]: error })))
     )
-  }
-
-  // if it's a plain object, return
-  if (result != null && typeof result === 'object') {
-    return of(setError(result))
   }
 
   // in all other cases wrap to an object

--- a/src/modules/validate/validate.spec.ts
+++ b/src/modules/validate/validate.spec.ts
@@ -188,8 +188,8 @@ describe('validate', () => {
           age(value) {
             if (!value) {
               return {
-                age: 'Hey!',
-                name: 'Heeeey!'
+                error: 'Hey!',
+                flag: true
               }
             }
           }
@@ -197,16 +197,20 @@ describe('validate', () => {
       })
 
       expect(app.getState().errors).toEqual({
-        age: 'Hey!',
-        name: 'Heeeey!'
+        age: {
+          error: 'Hey!',
+          flag: true
+        }
       })
 
       expect(app.getState().eventLog).toEqual([
         expect.objectContaining(initDone()),
         expect.objectContaining(
           setError({
-            age: 'Hey!',
-            name: 'Heeeey!'
+            age: {
+              error: 'Hey!',
+              flag: true
+            }
           })
         )
       ])


### PR DESCRIPTION
**Issue:** 
#24 Validate module breaks plain object errors
 
**Problem:**
To handle some cases we want to extend error with flags. But validate module turn this rules
```
validate({
    rules: {
         'someField': value => { error: 'Error message', flag: true }
    }
})
```
into state without field name key
```
errors: {
    error: 'Error message'
}
```