### PR TITLE
Add stapp-formbase in todo-mvc example

### DIFF
--- a/examples/todo-mvc/package.json
+++ b/examples/todo-mvc/package.json
@@ -10,6 +10,7 @@
     "redux": "^4.0.0",
     "reselect": "^3.0.1",
     "stapp": "^2.4.0-0",
+    "stapp-formbase": "^2.4.0-0",
     "stapp-persist": "^2.4.0-0",
     "stapp-react": "^2.4.0-0",
     "todomvc-app-css": "^2.0.0",


### PR DESCRIPTION
Hi, now example todo-mvc don't work because is not installed stapp-formbase
```
DependencyNotFoundError
Could not find dependency: 'stapp-formbase' relative to '/node_modules/stapp-react/lib/createComponents/createField.js'
```